### PR TITLE
Support browser PNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Building
 Joerd is a Python command line tool using `setuptools`. To install on a Debian or Ubuntu system, you need to install its dependencies:
 
 ```sh
-sudo apt-get install python-gdal
+sudo apt-get install python-gdal python-bs4 python-numpy gdal-bin
 ```
 
 (NOTE: not sure if this works: I installed GDAL-2.0.1 manually here, but I don't think it really needs it.)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,7 +15,7 @@ regions:
 outputs:
   - type: skadi
   - type: terrarium
-    zoom: 13
+    zooms: [9, 10, 11, 12, 13]
 sources:
   - type: etopo1
     url: https://www.ngdc.noaa.gov/mgg/global/relief/ETOPO1/data/bedrock/grid_registered/georeferenced_tiff/ETOPO1_Bed_g_geotiff.zip

--- a/joerd/command.py
+++ b/joerd/command.py
@@ -96,12 +96,6 @@ def joerd_main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
 
-    # check the actually installed GDAL version
-    gdal_version = gdal.VersionInfo()
-    gdal_major_version = int(gdal_version)/1000000
-    assert gdal_major_version >= 2, \
-        'Joerd needs GDAL >= 2.0.0, but got %r' % gdal_version
-
     parser = JoerdArgumentParser()
     subparsers = parser.add_subparsers()
 

--- a/joerd/composite.py
+++ b/joerd/composite.py
@@ -102,7 +102,7 @@ def compose(layers, dst_ds, dst_bbox, logger):
     # by any valid data values in later layers. so layers should be listed
     # in order of increasing detail.
     for layer in layers:
-        logger.info("Processing layer VRT: %r", layer.vrt_file())
+        logger.debug("Processing layer VRT: %r", layer.vrt_file())
 
         mem_ds = mem_drv.Create('', dst_x_size, dst_y_size, 1, dst_type)
         assert mem_ds is not None
@@ -128,4 +128,4 @@ def compose(layers, dst_ds, dst_bbox, logger):
         res = dst_band.WriteArray(new_data)
         assert res == gdal.CPLE_None
 
-    logger.info("Done composite.")
+    logger.debug("Done composite.")


### PR DESCRIPTION
16-bit PNGs don't display well in the browser, so it's helpful for testing and demoing to be able to generate 8-bit PNGs as well. This adds that functionality, as well as cleaning up a few other things noticed / fixed while deploying to EC2, notably changing the single zoom output to a list of zooms.

Connects to #9.

@rmarianski could you review, please?